### PR TITLE
resonance up

### DIFF
--- a/routines/adele/clp.csv
+++ b/routines/adele/clp.csv
@@ -70,3 +70,5 @@
     Resonance, direction=up, jump=False
 *, x=0.135, y=0.357, frequency=1, skip=True, adjust=False
     Resonance, direction=right, jump=False
+*, x=0.780, y=0.230, frequency=1, skip=True, adjust=False
+    Resonance, direction=up, jump=True


### PR DESCRIPTION
added an extra resonance point on the right side of the map for going up, to try and prevent getting stuck/jumping without being able to get up there

is there some way to disable points from being used outside of "required/optional pathing" like only using it for moving somewhere and not always using it every rotation ? ( could be nice for small platforms, or just other places you might want to add as positions to use in rare cases, but currently it kinda makes the player go there all the time wasting a tiny bit of time )